### PR TITLE
fix: subtract scrollbar width from full-width elements (resolves #57)

### DIFF
--- a/src/assets/scripts/app.js
+++ b/src/assets/scripts/app.js
@@ -18,3 +18,5 @@ window.accordions = new Accordion(".accordion", {
     header: "h3",
     icon: "<svg width=\"12\" height=\"12\" viewBox=\"0 0 12 12\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><line x1=\"1\" y1=\"5.85718\" x2=\"11\" y2=\"5.85718\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/><line class=\"vertical\" x1=\"6.14282\" y1=\"1\" x2=\"6.14282\" y2=\"11\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg>"
 });
+
+document.documentElement.style.setProperty("--scrollbar-width", (window.innerWidth - document.documentElement.clientWidth) + "px");

--- a/src/assets/styles/base/_helpers.scss
+++ b/src/assets/styles/base/_helpers.scss
@@ -81,7 +81,7 @@
 .bg--full {
     margin-left: 50%;
     transform: translateX(-50%);
-    width: 100vw;
+    width: calc(100vw - var(--scrollbar-width, 0));
 
     .wrapper {
         padding: var(--scale-8) var(--scale-4);

--- a/src/assets/styles/components/_navigation.scss
+++ b/src/assets/styles/components/_navigation.scss
@@ -63,7 +63,7 @@
     margin-top: calc(-1 * (var(--scale-4) + var(--scale-0)));
     padding-top: calc(var(--scale-4) + var(--scale-0));
     position: relative;
-    width: 100vw;
+    width: calc(100vw - var(--scrollbar-width, 0));
     z-index: 10;
 }
 

--- a/src/assets/styles/components/_table-of-contents.scss
+++ b/src/assets/styles/components/_table-of-contents.scss
@@ -15,7 +15,7 @@
     margin-left: calc(-1 * var(--scale-4));
     padding-left: var(--scale-4);
     padding-right: var(--scale-4);
-    width: 100vw;
+    width: calc(100vw - var(--scrollbar-width, 0));
 
     &:focus {
         background: var(--blue-600);
@@ -70,7 +70,7 @@
         height: rem(45);
         margin-left: calc(-1 * var(--scale-4));
         padding: 0 var(--scale-4);
-        width: 100vw;
+        width: calc(100vw - var(--scrollbar-width, 0));
     }
 }
 

--- a/src/assets/styles/layout/_content.scss
+++ b/src/assets/styles/layout/_content.scss
@@ -16,7 +16,7 @@
         background: white;
         margin-left: calc(-1 * var(--scale-4));
         padding: 0 var(--scale-4);
-        width: 100vw;
+        width: calc(100vw - var(--scrollbar-width, 0));
     }
 
     .inner-content {


### PR DESCRIPTION
The `.bg-full` utility was causing horizontal overflow because it didn't account for scrollbar width. This PR adds a utility to subtract the scrollbar width which should resolve the issue.