### PR TITLE
fix: attributes authors (#640) and community leadership (#642)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,17 +2,48 @@
 
 ## Copyright Holders
 
-Copyright 2020
+Copyright 2020-2025, The Community-Led Co-Design Toolkit Authors.
 
 This is the list of Community-Led Co-Design Toolkit copyright holders. It does not list all individual contributors
 because some have assigned copyright to an institution, only made minor changes, or their contributions no longer appear
 in the codebase. Please see the version control system's revision history for details on contributions.
 
 * OCAD University
+* Titania Veda
 
-## Contributors
+## Content Contributors
 
-Individual contributions can be viewed on the
+### Authors and Editors
+
+* Dana Ayotte
+* Cheryl Li
+* Sepideh Shahi
+* Titania Veda
+* Colin Clark
+* Gloria Bernal
+
+### Editorial Support and Feedback
+
+* Georgia MacKenzie
+* Raheel Waqar
+* Lauren Benetua
+* Nadine Foik
+* Sarah Luca
+* Salonie Muralidhara Hiriyur
+* Emma Back
+* Titania Veda
+* Clarence Tam
+* Samira Matan
+* Jannis Hegenwald
+
+## Code Contributors
+
+* Ned Zimmerman
+* Justin Obara
+* Jonathan Hung
+* Colin Clark
+
+Individual contributions to the platform's code can be viewed on the
 [Contributors](https://github.com/community-led-design/kit/graphs/contributors) page, or through the
 version control system's revision history.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # BSD 3-Clause License
 
-Copyright (c) 2020, OCAD University.  
+Copyright (c) 2020-2025, The Community-Led Co-Design Toolkit Authors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/_includes/partials/global/footer.njk
+++ b/src/_includes/partials/global/footer.njk
@@ -1,26 +1,20 @@
 <footer class="[ footer ] [ bg-blue-600 text-white ]" data-background="dark" role="contentinfo">
     <div class="wrapper">
-        <p>
-            <a href="https://idrc.ocadu.ca">
-                <span class="visually-hidden">Inclusive Design Research Centre</span>
-                {% include "svg/idrc-logo.svg" %}
-            </a>
-        </p>
         <div class="grid grid--lg-3">
             <div>
             <h2 class="h4">About</h2>
-            <p>The Community-Led Co-design Kit is a project initiated by the <a href="https://idrc.ocadu.ca/">Inclusive Design Research Centre</a>, funded by the <a href="https://hewlett.org/">Hewlett Foundation</a>.</p>
+            <p>The Community-Led Co-design Kit is maintained by a <a href="{{ '/about/' | url }}">community of contributors</a>. The project was initiated by the <a href="https://idrc.ocadu.ca/">Inclusive Design Research Centre</a> with funding from the <a href="https://hewlett.org/">Hewlett Foundation</a> and other sources.</p>
             </div>
             <div>
             <h2 class="h4">Contact us</h2>
-            <p>Want to give us feedback, contribute to this kit, or just get in touch? Email <a href="mailto:idrc@ocadu.ca">idrc@ocadu.ca</a>.</p>
+            <p>Want to give us feedback, contribute to this kit, or just get in touch? <a href="https://github.com/community-led-design/kit">Join us on Github</a>.</p>
             </div>
             <div>
-            <h2 class="h4">More resources by the IDRC</h2>
+            <h2 class="h4">More community design resources</h2>
             <ul role="list">
                 <li><a href="https://cities.inclusivedesign.ca/">Inclusive Cities Co-design Kit</a></li>
+                <li><a href="https://datacommunities.ca/toolkit/">Data Communities Toolkit</a></li>
                 <li><a href="https://guide.inclusivedesign.ca/">Inclusive Design Guide</a></li>
-                <li><a href="https://handbook.floeproject.org/">Inclusive Learning Design Handbook</a></li>
             </ul>
             </div>
         </div>

--- a/src/collections/pages/about.md
+++ b/src/collections/pages/about.md
@@ -8,77 +8,82 @@ eleventyNavigation:
 ---
 ## About this kit
 
-The Community-led Co-design Kit is an initiative out of the [Inclusive Design Research Centre](https://idrc.ocadu.ca/) in Toronto, Canada. The project is funded by the [Hewlett Foundation](https://hewlett.org/), for the [Flexible Learning Open Education project](https://floeproject.org/). This is our first iteration of the kit, and there is much more content we'd like to add down the road.
+The Community-led Co-design Kit is written, designed, and governed by an
+ open community of contributors. All content is owned by its respective authors,
+ and is distributed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="external license">
+ Creative Commons Attribution 4.0 License</a>.
+
+The goal of the Kit is to provide tangible, example-driven techniques and
+ perspectives for practicing designers to use when helping communities to
+ design, own, and govern their own technology design projects.
+
+## To cite this kit
+
+<cite>Ayotte, Dana, Cheryl Li, Sepideh Shahi, Titania Veda, Colin Clark, and Gloria Bernal.
+ "Community-Led Co-Design Kit." 2021. Accessed December 1, 2025. https://community-led.design.</cite>
 
 ## Making this kit
 
-The learnings and insights in this kit have grown out of our experiences working with communities on projects such as [Co-designing Inclusive Cities](https://cities.inclusivedesign.ca/), [Platform Co-op Development Kit](https://platform.coop/), and [Coding to Learn and Create](https://www.codelearncreate.org/). In addition our own projects, our ideas were also inspired by practitioners and advocates of disability justice, anti-oppression movements, and decolonialist research and design methodologies.
+The learnings and insights in this kit have grown out of our experiences working with communities on projects such as
+ [Co-designing Inclusive Cities](https://cities.inclusivedesign.ca/),
+ [Platform Co-op Development Kit](https://platform.coop/), and
+ [Coding to Learn and Create](https://www.codelearncreate.org/).
+ In addition our own projects, our ideas were also inspired by practitioners and advocates of disability justice,
+ anti-oppression movements, and decolonialist research and design methodologies.
 
-We were fortunate enough to have many people in our community share their feedback with us. While we weren't able to address all of it in this first version, we will be incorporating it in future versions. [See the to-do's based on their feedback.](https://www.notion.so/9977b0e62a104b148028b2272c049edf?v=1d8fe21d5a494c37a67860c8a1995379)
+We were fortunate enough to have many people in our community share their feedback with us.
+While we weren't able to address all of it in this first version, we will be incorporating it in future versions.
+[See the to-do's based on their feedback.](https://www.notion.so/9977b0e62a104b148028b2272c049edf?v=1d8fe21d5a494c37a67860c8a1995379)
 
 ## [](https://www.notion.so/9977b0e62a104b148028b2272c049edf?v=1d8fe21d5a494c37a67860c8a1995379)Want to contribute?
 
-Anyone can contribute to this kit. We welcome you to email us directly at idrc@ocadu.ca, or join our [project chatroom via Matrix.](https://matrix.to/#/#fluid-codesign-kit:matrix.org?via=matrix.org)
+Anyone can contribute to this kit. We welcome you to [join us on Github](https://github.com/community-led-design/kit).
 
-### **You can contribute in the following ways:**
+### You can contribute in the following ways:
 
-**Contribute your co-design experience**
+#### Contribute your co-design experience
 
 * Write a guide on a specific topic
 * Share an activity that you like to use
 * Share a tool that you've found useful
 * Write a case study about how you've done community-led co-design
 
-**Contribute your skills**
+#### Contribute your skills
 
 * Copywriting: help us get better at explaining complex concepts in simple and accessible language
 * Illustration: help us visually explain concepts
 * Multi-media: help us describe our content in alternative forms such as audio and video
 * Translation: help us translate our content to other languages, including sign languages like ASL and LSQ.
 
-**Give us feedback**
+#### Give us feedback
 
 * Give us feedback on how to make this website more valuable, usable, or accessible.
 * Tell us how you're using this kit - what's helpful about it, and what could be improved.
 
-If you don't see a way in which you'd like to contribute on this list, please contact us and tell us what would work for you.
+If you don't see a way in which you'd like to contribute on this list,
+please contact us and tell us what would work for you.
 
 ## Contributors
 
 ### Authors and editors
 
-Dana Ayotte
-
-Cheryl Li
-
-Sepideh Shahi
-
-Titania Veda
-
-Colin Clark
-
-Gloria Bernal
+* Dana Ayotte
+* Cheryl Li
+* Sepideh Shahi
+* Titania Veda
+* Colin Clark
+* Gloria Bernal
 
 ### Feedback
 
-Georgia MacKenzie
-
-Raheel Waqar
-
-Lauren Benetua
-
-Nadine Foik
-
-Sarah Luca
-
-Salonie Muralidhara Hiriyur
-
-Emma Back
-
-Titania Veda
-
-Clarence Tam
-
-Samira Matan
-
-Jannis Hegenwald
+* Georgia MacKenzie
+* Raheel Waqar
+* Lauren Benetua
+* Nadine Foik
+* Sarah Luca
+* Salonie Muralidhara Hiriyur
+* Emma Back
+* Titania Veda
+* Clarence Tam
+* Samira Matan
+* Jannis Hegenwald


### PR DESCRIPTION
This PR resolves #640 and #642 by providing full attribution for content authors in the AUTHORS.md file, as well as describing the community-driven nature of the project in the site's footer and About page. I also added a note about how to correctly cite the Kit.

I also had to make some minor markdown formatting changes to the About page in order satisfy the pre-commit linter checks.